### PR TITLE
Stop Limit Order #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btcmarkets-australia",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Typescript wrapper for BTCMarkets Exchange",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,7 +4,7 @@ import * as rp from 'request-promise';
 import { HmacHeaders } from './interfaces/hmacResponse.interface';
 
 export class Common {
-  private accountFloat: number;
+  public accountFloat: number;
   private uri: string;
 
   constructor() {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -259,4 +259,17 @@ describe('Index', () => {
 
     assert.strictEqual(hmacStub.callCount, 1);
   });
+
+  it('should call getFloat', async () => {
+    const btcm = new BTCMarkets('MyApiKey', 'MySecretKey');
+
+    const resp = btcm.getFloat();
+
+    const expectedResponse = 100000000;
+
+    assert.strictEqual(resp, expectedResponse);
+
+    assert.strictEqual(rpStub.callCount, 0);
+    assert.strictEqual(hmacStub.callCount, 0);
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,27 +25,27 @@ export class BTCMarkets {
     this.commonClass = new Common();
   }
 
-  public account() {
+  public account(): Account {
     return this.accountClass;
   }
 
-  public fundTransfer() {
+  public fundTransfer(): FundTransfer {
     return this.fundTransferClass;
   }
 
-  public market() {
+  public market(): Market {
     return this.marketClass;
   }
 
-  public trading() {
+  public trading(): Trading {
     return this.tradingClass;
   }
 
-  public transaction() {
+  public transaction(): Transaction {
     return this.transactionClass;
   }
 
-  public getFloat() {
+  public getFloat(): number {
     return this.commonClass.accountFloat;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Account } from './account';
+import { Common } from './common';
 import { FundTransfer } from './fundTransfer';
 import { Market } from './market';
 import { Trading } from './trading';
@@ -10,6 +11,7 @@ export class BTCMarkets {
   private marketClass: Market;
   private tradingClass: Trading;
   private transactionClass: Transaction;
+  private commonClass: Common;
 
   constructor(
     publicKey?: string,
@@ -20,6 +22,7 @@ export class BTCMarkets {
     this.marketClass = new Market();
     this.tradingClass = new Trading(publicKey, privateKey);
     this.transactionClass = new Transaction(publicKey, privateKey);
+    this.commonClass = new Common();
   }
 
   public account() {
@@ -40,5 +43,9 @@ export class BTCMarkets {
 
   public transaction() {
     return this.transactionClass;
+  }
+
+  public getFloat() {
+    return this.commonClass.accountFloat;
   }
 }

--- a/src/interfaces/trading/create.interface.ts
+++ b/src/interfaces/trading/create.interface.ts
@@ -6,4 +6,4 @@ export interface Create extends CommonResponseV2 {
 }
 
 export type CreateOrderSideType = 'Bid' | 'Ask';
-export type CreateOrdertypeType = 'Limit' | 'Market';
+export type CreateOrdertypeType = 'Limit' | 'Market' | 'Stop Limit';

--- a/src/trading.spec.ts
+++ b/src/trading.spec.ts
@@ -108,6 +108,87 @@ describe('Trading', () => {
     assert.strictEqual(commonStub.callCount, 1);
   });
 
+  it('should call create for stop limit order', async () => {
+    hmacStub.returns({
+      path: '/order/create',
+      headers: {
+        apiKey: 'MyApiKey',
+        timestamp: 1541581502000,
+        signature: 'YWJjMTIz',
+      },
+      body: {
+        clientRequestId: 'abc123',
+        currency: 'AUD',
+        instrument: 'BTC',
+        orderSide: 'Ask',
+        ordertype: 'Stop Limit',
+        price: 850043000000,
+        volume: 155000000,
+        triggerPrice: 830015000000,
+      },
+    });
+
+    commonStub.returns({
+      response: true,
+    });
+
+    const resp: any = await trading.create('BTC', 'AUD', 8500.43, 1.55, 'Ask', 'Stop Limit', 'abc123', 8300.15);
+
+    const expectedMockReturn = {
+      response: true,
+    };
+
+    assert.deepEqual(resp, expectedMockReturn);
+
+    const expectedHmacArgs = [
+      [
+        '/order/create',
+        'MyApiKey',
+        'MyApiSecret',
+        null,
+        {
+          clientRequestId: 'abc123',
+          currency: 'AUD',
+          instrument: 'BTC',
+          orderSide: 'Ask',
+          ordertype: 'Stop Limit',
+          price: 850043000000,
+          volume: 155000000,
+          triggerPrice: 830015000000,
+        },
+      ],
+    ];
+
+    assert.deepEqual(hmacStub.args, expectedHmacArgs);
+    assert.strictEqual(hmacStub.callCount, 1);
+
+    const expectedCommonArgs = [
+      [
+        'POST',
+        '/order/create',
+        null,
+        {
+          clientRequestId: 'abc123',
+          currency: 'AUD',
+          instrument: 'BTC',
+          orderSide: 'Ask',
+          ordertype: 'Stop Limit',
+          price: 850043000000,
+          volume: 155000000,
+          triggerPrice: 830015000000,
+        },
+        {
+          apiKey: 'MyApiKey',
+          signature: 'YWJjMTIz',
+          timestamp: 1541581502000,
+        },
+      ],
+    ];
+
+    assert.deepEqual(commonStub.args, expectedCommonArgs);
+    assert.strictEqual(commonStub.callCount, 1);
+  });
+
   it('should call cancel', async () => {
     hmacStub.returns({
       path: '/order/cancel',

--- a/src/trading.ts
+++ b/src/trading.ts
@@ -31,6 +31,7 @@ export class Trading {
     orderSide: CreateOrderSideType,
     ordertype: CreateOrdertypeType,
     clientRequestId: string,
+    triggerPrice?: number,
   ): Promise<Create> {
     const body = {
       instrument: instrument.toUpperCase(),
@@ -40,7 +41,12 @@ export class Trading {
       orderSide,
       ordertype,
       clientRequestId,
+      triggerPrice: this.common.convertFigure(true, triggerPrice),
     };
+
+    if (ordertype !== 'Stop Limit') {
+      delete body.triggerPrice;
+    }
 
     const r = createHmac('/order/create', this.publicKey, this.privateKey, null, body);
 


### PR DESCRIPTION
- Added support for `Stop Loss` orders
- Added access to `accountFloat` -> `btcm.getFloat()`